### PR TITLE
Fix: Attributes not passed to parent constructor

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -14,6 +14,6 @@ class Model extends Eloquent
         if (!static::resolveDatabaseManagerInstance()) {
             static::autoloadDatabaseManager();
         }
-        parent::__construct($attributes = []);
+        parent::__construct($attributes);
     }
 }


### PR DESCRIPTION
Fixes bug where constructor attributes are not passed to parent constructor.

I'd be happy to provide unit test, if you are ok with phpunit as dependency.